### PR TITLE
Adding experimental composition pipeline for IBL fragment user modifications.

### DIFF
--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -218,9 +218,17 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         
         vert = "ibl_v.vert"
         frag = "ibl_f.frag"
+
+        extant_append_shaders = []
+        local_shader_dir = os.listdir()
         
-        base.complexpbr_append_shader_count = 0
-        base.complexpbr_append_shader_count += 1
+        for item in local_shader_dir:
+            if 'ibl_f_' in item:
+                extant_append_shaders.append(item)
+
+        extant_append_shaders = sorted(extant_append_shaders)
+        top_extant_shader_val = int(extant_append_shaders.pop().strip('ibl_f_').strip('.frag'))
+        base.complexpbr_append_shader_count = top_extant_shader_val + 1
         
         append_shader_file = ''
         input_body_mod = ''

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -223,11 +223,34 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         base.complexpbr_append_shader_count += 1
         
         append_shader_file = ''
-        input_body_mod = 'vec3 test_albedo = vec3(0.0);'
-        input_main_mod = 'vec3 something_else = vec3(0.0);'
+        input_body_mod = ''
+        input_main_mod = ''
         input_body_reached = False
         main_reached = False
         end_reached = False
+        
+        if input_string == '':
+            input_body_mod = 'vec3 test_albedo = vec3(0.0);'
+            input_main_mod = 'vec3 something_else = vec3(0.0);'
+        else:
+            for line in input_string.split('\n'):
+                if 'void main' in line:
+                    main_reached = True
+                
+                if not main_reached:
+                    input_body_mod += (line + '\n')
+                    
+            main_reached = False
+             
+            for line in input_string.split('\n'):
+                if 'void main' in line:
+                    main_reached = True
+                
+                if main_reached:
+                    if not 'void main' in line:
+                        input_main_mod += (line + '\n')
+                    
+            main_reached = False
         
         with open(frag) as shaderfile:
             shaderstr = shaderfile.read()
@@ -242,7 +265,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
             for line in shaderstr.split('\n'):
                 if 'const float LIGHT_CUTOFF' in line:
                     # print(line)
-                    print('input body reached')
+                    # print('input body reached')
                     input_body_reached = True
                     
                 if 'void main' in line:
@@ -257,7 +280,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
                 if 'void main' in line:
                     main_reached = True
                     
-                if 'color.rgb' in line:
+                if 'vec3 spec_color = F0;' in line:
                     end_reached = True
                     # print(line)
                     # print('end reached')
@@ -270,7 +293,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
             end_reached = False
             
             for line in shaderstr.split('\n'):
-                if 'color.rgb' in line:
+                if 'vec3 spec_color = F0;' in line:
                     end_reached = True
                     # print('end reached')
                     

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -227,8 +227,12 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
                 extant_append_shaders.append(item)
 
         extant_append_shaders = sorted(extant_append_shaders)
-        top_extant_shader_val = int(extant_append_shaders.pop().strip('ibl_f_').strip('.frag'))
-        base.complexpbr_append_shader_count = top_extant_shader_val + 1
+        
+        try:
+            top_extant_shader_val = int(extant_append_shaders.pop().strip('ibl_f_').strip('.frag'))
+            base.complexpbr_append_shader_count = top_extant_shader_val + 1
+        except:
+            base.complexpbr_append_shader_count = 1
         
         append_shader_file = ''
         input_body_mod = ''

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -232,16 +232,16 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         with open(frag) as shaderfile:
             shaderstr = shaderfile.read()
             for line in shaderstr.split('\n'):
-                # print(line)
                 append_shader_file += line
                 if 'uniform float specular_factor' in line:
                     break
                     
             append_shader_file += (input_body_mod + '\n')
+            print(append_shader_file)
             
             for line in shaderstr.split('\n'):
                 if 'const float LIGHT_CUTOFF' in line:
-                    print(line)
+                    # print(line)
                     print('input body reached')
                     input_body_reached = True
                     
@@ -259,26 +259,30 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
                     
                 if 'color.rgb' in line:
                     end_reached = True
-                    print(line)
+                    # print(line)
+                    print('end reached')
                     
                 if main_reached and not end_reached:
                     append_shader_file += line
                     
             append_shader_file += (input_main_mod + '\n')
             
+            end_reached = False
+            
             for line in shaderstr.split('\n'):
                 if 'color.rgb' in line:
                     end_reached = True
-                    print(line)
+                    print('end reached')
                     
                 if end_reached:
                     append_shader_file += line
-                
-            for line in append_shader_file.split('\n'):
-                print(line + '\n')
                     
         out_v = open('ibl_f_' + str(base.complexpbr_append_shader_count) + '.frag', 'w')
-        out_v.write(append_shader_file)
+        
+        for line in append_shader_file.split('\n'):
+            out_v.write(line)
+            out_v.write('\n')
+            
         out_v.close()
             
         frag = 'ibl_f_' + str(base.complexpbr_append_shader_count) + '.frag'

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -223,7 +223,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         base.complexpbr_append_shader_count += 1
         
         append_shader_file = ''
-        input_body_mod = 'in vec3 test_albedo = vec3(0.0);'
+        input_body_mod = 'vec3 test_albedo = vec3(0.0);'
         input_main_mod = 'vec3 something_else = vec3(0.0);'
         input_body_reached = False
         main_reached = False
@@ -232,12 +232,12 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         with open(frag) as shaderfile:
             shaderstr = shaderfile.read()
             for line in shaderstr.split('\n'):
-                append_shader_file += line
+                append_shader_file += (line + '\n')
                 if 'uniform float specular_factor' in line:
                     break
                     
             append_shader_file += (input_body_mod + '\n')
-            print(append_shader_file)
+            # print(append_shader_file)
             
             for line in shaderstr.split('\n'):
                 if 'const float LIGHT_CUTOFF' in line:
@@ -249,7 +249,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
                     main_reached = True
                                        
                 if input_body_reached and not main_reached:
-                    append_shader_file += line
+                    append_shader_file += (line + '\n')
                     
             main_reached = False
                     
@@ -260,10 +260,10 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
                 if 'color.rgb' in line:
                     end_reached = True
                     # print(line)
-                    print('end reached')
+                    # print('end reached')
                     
                 if main_reached and not end_reached:
-                    append_shader_file += line
+                    append_shader_file += (line + '\n')
                     
             append_shader_file += (input_main_mod + '\n')
             
@@ -272,10 +272,10 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
             for line in shaderstr.split('\n'):
                 if 'color.rgb' in line:
                     end_reached = True
-                    print('end reached')
+                    # print('end reached')
                     
                 if end_reached:
-                    append_shader_file += line
+                    append_shader_file += (line + '\n')
                     
         out_v = open('ibl_f_' + str(base.complexpbr_append_shader_count) + '.frag', 'w')
         

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -289,7 +289,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
             if 'void main' in line:
                 main_reached = True
                 
-            if 'vec3 spec_color = F0;' in line:
+            if 'outputNormal = texture(p3d_Texture2, v_texcoord).rgb * 0.5 + vec3(0.5);' in line:
                 end_reached = True
                 # print(line)
                 # print('end reached')
@@ -302,7 +302,7 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
         end_reached = False
         
         for line in shaderstr.split('\n'):
-            if 'vec3 spec_color = F0;' in line:
+            if 'outputNormal = texture(p3d_Texture2, v_texcoord).rgb * 0.5 + vec3(0.5);' in line:
                 end_reached = True
                 # print('end reached')
                 

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -221,16 +221,17 @@ def append_shader(input_string,node=None,intensity=1.0,env_cam_pos=None,env_res=
     
     for item in local_shader_dir:
         if 'ibl_f_' in item:
-            extant_append_shaders.append(item)
+            item = item.strip('ibl_f_').strip('.frag')
+            extant_append_shaders.append(int(item))
 
     extant_append_shaders = sorted(extant_append_shaders)
     
     try:
-        top_extant_shader_val = int(extant_append_shaders.pop().strip('ibl_f_').strip('.frag'))
+        top_extant_shader_val = extant_append_shaders.pop()
         base.complexpbr_append_shader_count = top_extant_shader_val + 1
     except:
         base.complexpbr_append_shader_count = 1
-    
+
     append_shader_file = ''
     input_body_mod = ''
     input_main_mod = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "0.5.6"
+version = "0.5.7"
 name = "panda3d-complexpbr"
 authors = [
     {name = "Logan Bier"}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='panda3d-complexpbr',
-    version='0.5.6',
+    version='0.5.7',
     packages=['complexpbr'],
     package_data={
        "": ["*.txt","*.vert","*.frag","*.png"],


### PR DESCRIPTION
This merge from the Composition branch allows users to call `complexpbr.append_shader('custom_fragment_injection_string', node)` after the initial complexpbr.apply_shader() call has been performed. A bare "void main" in the injection string is all that is required to let complexpbr know to separate the rest of the supplied shader string into the main function of the "model-level" fragment shader.

Example usage:
```
# call apply_shader() first to init
complexpbr.apply_shader(test_sphere)
complexpbr.apply_shader(test_sphere_2)

# call the append_shader function
random_func = 'float default_noise(vec2 n)\n{\nfloat n2  = fract(sin(dot(n.xy,vec2(11.78,77.443)))*44372.7263);\nreturn n2;\n}'
custom_append_shader = random_func + '\n void main \n    o_color += default_noise(vec2(3.3));'
complexpbr.append_shader(custom_append_shader, test_sphere)
```