### PR TITLE
Introduction of optional default lighting, shadowed color boosting.

### DIFF
--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -158,7 +158,7 @@ def skin(node):
     node.set_attrib(base.complexpbr_skin_attrib)
 
 def apply_shader(node=None,intensity=1.0,env_cam_pos=None,env_res=256,lut_fill=[1.0,0.0,0.0],complexpbr_z_tracking=False,
-custom_dir='',default_lighting=False,shadow_boost=1.5):
+custom_dir='',default_lighting=False,shadow_boost=0.01):
     global complexpbr_init
     
     base.complexpbr_custom_dir = custom_dir
@@ -419,7 +419,7 @@ def remove_shader_files():
         pass
         
 def complexpbr_default_lighting():
-    amb_light = AmbientLight('amblight')
+    amb_light = AmbientLight('amb_light')
     amb_light.set_color(Vec4(Vec3(1),1))
     amb_light_node = base.render.attach_new_node(amb_light)
     base.render.set_light(amb_light_node)

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -1,37 +1,15 @@
 import os, time
 from pathlib import Path
 from panda3d.core import Shader, ShaderAttrib, TextureStage, TexGenAttrib, NodePath
-from panda3d.core import Texture, ATS_none, Vec3, AuxBitplaneAttrib, PNMImage, AntialiasAttrib
+from panda3d.core import Texture, ATS_none, Vec3, Vec4, AuxBitplaneAttrib, PNMImage, AntialiasAttrib
 from panda3d.core import load_prc_file_data
 from direct.stdpy import threading2
 from direct.filter.FilterManager import FilterManager
+from panda3d.core import PointLight, Spotlight, AmbientLight, PerspectiveLens
 
 
 complexpbr_init = True
 shader_dir = os.path.join(os.path.dirname(__file__), '')
-
-def remove_shader_files():
-    os.remove(base.complexpbr_custom_dir + 'ibl_v.vert')
-    os.remove(base.complexpbr_custom_dir + 'ibl_f.frag')
-    
-    try:
-        os.remove(base.complexpbr_custom_dir + 'min_v.vert')
-        os.remove(base.complexpbr_custom_dir + 'min_f.frag')
-    except:
-        print('complexpbr message: Screenspace shaders are not present for deletion.')
-        
-    try:
-        local_shader_dir = os.listdir(base.complexpbr_custom_dir)
-        
-        for item in local_shader_dir:
-            if 'ibl_f_' in item:
-                os.remove(item)
-            
-            elif 'ibl_v_' in item:
-                os.remove(item)
-    
-    except:
-        pass
 
 def set_cubebuff_inactive():
     def set_thread():
@@ -133,7 +111,7 @@ def screenspace_init():
     base.screen_quad = screen_quad
     base.render.set_antialias(AntialiasAttrib.MMultisample)
 
-def complexpbr_rig_init(node, intensity, lut_fill):
+def complexpbr_rig_init(node, intensity, lut_fill, shadow_boost):
     load_prc_file_data('', 'hardware-animated-vertices #t')
     load_prc_file_data('', 'framebuffer-srgb #t')
     load_prc_file_data('', 'framebuffer-depth-32 1')
@@ -166,6 +144,7 @@ def complexpbr_rig_init(node, intensity, lut_fill):
     node.set_shader_input("cubemaptex", base.cube_buffer.get_texture())
     node.set_shader_input("brdfLUT", brdf_lut_tex)
     node.set_shader_input("ao", intensity)
+    node.set_shader_input("shadow_boost", shadow_boost)
     node.set_shader_input("displacement_scale", displacement_scale_val)
     node.set_shader_input("displacement_map", displacement_map)
     node.set_shader_input("specular_factor", specular_factor)
@@ -179,7 +158,7 @@ def skin(node):
     node.set_attrib(base.complexpbr_skin_attrib)
 
 def apply_shader(node=None,intensity=1.0,env_cam_pos=None,env_res=256,lut_fill=[1.0,0.0,0.0],complexpbr_z_tracking=False,
-custom_dir=''):
+custom_dir='',default_lighting=False,shadow_boost=1.5):
     global complexpbr_init
     
     base.complexpbr_custom_dir = custom_dir
@@ -212,7 +191,13 @@ custom_dir=''):
         base.complexpbr_z_tracking = complexpbr_z_tracking
         base.complexpbr_append_shader_count = 0
 
-    complexpbr_rig_init(node, intensity=intensity, lut_fill=lut_fill)
+    complexpbr_rig_init(node, intensity=intensity, lut_fill=lut_fill, shadow_boost=shadow_boost)
+    
+    if default_lighting:
+        try:
+            complexpbr_default_lighting()
+        except:
+            print('complexpbr message: Default lighting setup failed.')
     
 def append_shader(node=None,frag_body_mod='',frag_main_mod='',vert_body_mod='',vert_main_mod='',intensity=1.0,env_cam_pos=None,
 env_res=256,lut_fill=[1.0,0.0,0.0],complexpbr_z_tracking=False):
@@ -410,6 +395,51 @@ env_res=256,lut_fill=[1.0,0.0,0.0],complexpbr_z_tracking=False):
         base.complexpbr_z_tracking = complexpbr_z_tracking
 
     complexpbr_rig_init(node, intensity=intensity, lut_fill=lut_fill)
+    
+def remove_shader_files():
+    os.remove(base.complexpbr_custom_dir + 'ibl_v.vert')
+    os.remove(base.complexpbr_custom_dir + 'ibl_f.frag')
+    
+    try:
+        os.remove(base.complexpbr_custom_dir + 'min_v.vert')
+        os.remove(base.complexpbr_custom_dir + 'min_f.frag')
+    except:
+        print('complexpbr message: Screenspace shaders are not present for deletion.')
+        
+    try:
+        local_shader_dir = os.listdir(base.complexpbr_custom_dir)
+        
+        for item in local_shader_dir:
+            if 'ibl_f_' in item:
+                os.remove(item)
+            
+            elif 'ibl_v_' in item:
+                os.remove(item)
+    except:
+        pass
+        
+def complexpbr_default_lighting():
+    amb_light = AmbientLight('amblight')
+    amb_light.set_color(Vec4(Vec3(1),1))
+    amb_light_node = base.render.attach_new_node(amb_light)
+    base.render.set_light(amb_light_node)
+
+    slight_1 = Spotlight('slight_1')
+    slight_1.set_color(Vec4(Vec3(5),1))
+    slight_1.set_shadow_caster(True, 8192, 8192)
+    # slight_1.set_attenuation((0.5,0,0.000005))
+    lens = PerspectiveLens()
+    slight_1.set_lens(lens)
+    slight_1.get_lens().set_fov(120)
+    slight_1_node = base.render.attach_new_node(slight_1)
+    slight_1_node.set_pos(50, 50, 90)
+    slight_1_node.look_at(0,0,0.5)
+    base.render.set_light(slight_1_node)
+
+    env_light_1 = PointLight('env_light_1')
+    env_light_1.set_color(Vec4(Vec3(1),1))
+    env_light_1 = base.render.attach_new_node(env_light_1)
+    env_light_1.set_pos(0,0,-1)
 
 class Shaders:
     def __init__(self):

--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -158,7 +158,7 @@ def skin(node):
     node.set_attrib(base.complexpbr_skin_attrib)
 
 def apply_shader(node=None,intensity=1.0,env_cam_pos=None,env_res=256,lut_fill=[1.0,0.0,0.0],complexpbr_z_tracking=False,
-custom_dir='',default_lighting=False,shadow_boost=0.01):
+custom_dir='',default_lighting=False,shadow_boost=0.0):
     global complexpbr_init
     
     base.complexpbr_custom_dir = custom_dir

--- a/complexpbr/ibl_f.frag
+++ b/complexpbr/ibl_f.frag
@@ -206,7 +206,7 @@ void main()
         float shadowSpot = smoothstep(spotcutoff-SPOTSMOOTH, spotcutoff+SPOTSMOOTH, spotcos);
 
         float shadowCaster = textureProj(p3d_LightSource[i].shadowMap, v_shadow_pos[i]);
-        float shadow = (shadowSpot * shadowCaster * attenuation_factor) * shadow_boost;
+        float shadow = shadowSpot * shadowCaster * attenuation_factor;
 
         FunctionParameters func_params;
         func_params.n_dot_l = clamp(dot(N, l), 0.0, 1.0);
@@ -226,7 +226,7 @@ void main()
         vec3 diffuse_contrib = (diffuse_color * p3d_LightModel.ambient.rgb) * diffuse_function(func_params);
         vec3 spec_contrib = vec3(F0 * V * D);
         color.rgb += func_params.n_dot_l * lightcol * (diffuse_contrib + spec_contrib) * shadow;
-        color.rgb += albedo.rgb * (roughness * shadow_boost);
+        color.rgb += albedo.rgb * shadow_boost; // node-level shadow boost heuristic
     }
     
     vec3 ibl = getIBL(N, V, F0, diffuse_color, roughness);

--- a/complexpbr/ibl_f.frag
+++ b/complexpbr/ibl_f.frag
@@ -22,6 +22,7 @@ in vec4 v_shadow_pos[MAX_LIGHTS];
 
 uniform float ao;
 uniform float specular_factor;
+uniform float shadow_boost;
 
 const float LIGHT_CUTOFF = 0.001;
 const float SPOTSMOOTH = 0.1;
@@ -91,9 +92,9 @@ vec3 getIBL(vec3 N, vec3 V, vec3 F0, vec3 diffuse_color, float roughness)
     if (roughness < 0.7) 
         prefilteredColor = textureLod(cubemaptex, R, roughness * MAX_REFLECTION_LOD).rgb;
     else if (roughness >= 0.7)
-        if (roughness < 0.9)
+        if (roughness < 0.99)
             prefilteredColor = textureLod(cubemaptex, R, roughness * MAX_REFLECTION_LOD).rgb * vec3(0.04);
-    else if (roughness >= 0.9) 
+    else if (roughness >= 0.99) 
         prefilteredColor = prefilteredColor;
     vec2 brdf = texture(brdfLUT, vec2(max(dot(N, V), 0.0), roughness)).rg;
     vec3 specular = prefilteredColor * (kS * brdf.x + brdf.y);
@@ -205,7 +206,7 @@ void main()
         float shadowSpot = smoothstep(spotcutoff-SPOTSMOOTH, spotcutoff+SPOTSMOOTH, spotcos);
 
         float shadowCaster = textureProj(p3d_LightSource[i].shadowMap, v_shadow_pos[i]);
-        float shadow = shadowSpot * shadowCaster * attenuation_factor;
+        float shadow = (shadowSpot * shadowCaster * attenuation_factor) * shadow_boost;
 
         FunctionParameters func_params;
         func_params.n_dot_l = clamp(dot(N, l), 0.0, 1.0);
@@ -225,6 +226,7 @@ void main()
         vec3 diffuse_contrib = (diffuse_color * p3d_LightModel.ambient.rgb) * diffuse_function(func_params);
         vec3 spec_contrib = vec3(F0 * V * D);
         color.rgb += func_params.n_dot_l * lightcol * (diffuse_contrib + spec_contrib) * shadow;
+        color.rgb += albedo.rgb * (roughness * shadow_boost);
     }
     
     vec3 ibl = getIBL(N, V, F0, diffuse_color, roughness);


### PR DESCRIPTION
This PR introduces an optional default lighting setup for users who do not wish to set up their own lights.

Instantiating the optional default lighting: `complexpbr.apply_shader(self.render, default_lighting=True)`

The capability to boost the observable color in shadowed regions of specific models allows users to selectively produce better detail renders under complexpbr's default material and lighting models.

Example usage of the new shadow_boost input parameter: 
`if sphere_choice in ['1m_sphere_black_marble','1m_sphere_concrete_1','1m_sphere_bright_1']:
    sphere_model.set_shader_input('shadow_boost', 0.5)`