### PR TITLE
Fixed bug with removing shader files in custom dir

### DIFF
--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -393,10 +393,10 @@ def remove_shader_files():
         
         for item in local_shader_dir:
             if 'ibl_f_' in item:
-                os.remove(item)
+                os.remove(base.complexpbr_custom_dir + item)
             
             elif 'ibl_v_' in item:
-                os.remove(item)
+                os.remove(base.complexpbr_custom_dir + item)
     except:
         pass
         


### PR DESCRIPTION
The files generated with `append_shader` was not being properly removed when calling `remove_shader_files`. This PR should fix that issue.