### PR TITLE
Revert "Fixed bug with removing shader files in custom dir"

### DIFF
--- a/complexpbr/__init__.py
+++ b/complexpbr/__init__.py
@@ -393,10 +393,10 @@ def remove_shader_files():
         
         for item in local_shader_dir:
             if 'ibl_f_' in item:
-                os.remove(base.complexpbr_custom_dir + item)
+                os.remove(item)
             
             elif 'ibl_v_' in item:
-                os.remove(base.complexpbr_custom_dir + item)
+                os.remove(item)
     except:
         pass
         


### PR DESCRIPTION
Reverting rayanalysis/panda3d-complexpbr#12 due to it not working properly with a non-custom base directory input. I will be uploading a rewritten and simplified remove_shader_files() function shortly.